### PR TITLE
Make migrations use env-provided database URLs with SQLite fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,11 @@ CORS_ORIGINS=["http://localhost:3000", "http://localhost:8000"]
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================
-# PostgreSQL Database
-DATABASE_URL=postgresql://devops_user:devops_password@localhost:5432/devops_control_tower
+# Database
+# Defaults to a local SQLite file for development. Override DATABASE_URL to
+# point at an external Postgres instance when needed (e.g.,
+# postgresql+psycopg://user:pass@host:5432/devops_control_tower).
+DATABASE_URL=sqlite:///./devops_control_tower.db
 DATABASE_ECHO=false
 
 # Redis Cache & Message Broker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Core Components (Current)
 5. Postgres
 	•	Stores all task rows.
 	•	Must be reachable via DATABASE_URL env variable.
+	•	Local development should default to a sandboxed SQLite database (sqlite:///./devops_control_tower.db); point DATABASE_URL at Postgres only when explicitly targeting an external instance.
 
 6. Docker Compose
 	•	Runs:

--- a/README.md
+++ b/README.md
@@ -170,10 +170,15 @@ devops-control-tower/
 ## 🚦 Getting Started
 
 ### Prerequisites
+
 - Python 3.13+
-- Docker & Docker Compose
-- Kubernetes cluster (local or cloud)
 - Git
+- (Optional) Docker & Docker Compose
+- (Optional) Kubernetes cluster (local or cloud)
+
+Postgres is only required when you explicitly point `DATABASE_URL` at an external
+instance. By default the project runs against a local SQLite database so no
+system packages are needed for development.
 
 ### Quick Setup
 ```bash
@@ -181,22 +186,30 @@ devops-control-tower/
 git clone https://github.com/your-org/devops-control-tower.git
 cd devops-control-tower
 
-# Install dependencies
-poetry install
+# Create and activate a local virtual environment
+python -m venv .venv
+source .venv/bin/activate
 
-# Activate virtual environment
-poetry shell
+# Install Python dependencies
+pip install --upgrade pip
+pip install -e .
 
-# Set up configuration
+# Set up configuration (defaults to local SQLite)
 cp .env.example .env
-# Edit .env with your settings
+export DATABASE_URL=${DATABASE_URL:-"sqlite:///./devops_control_tower.db"}
 
-# Start development environment
-docker-compose up -d
+# Run database migrations against the local database
+alembic upgrade head
 
-# Initialize the platform
-poetry run python scripts/setup.py
+# Start the FastAPI application
+python -m devops_control_tower.main
 ```
+
+To use an external Postgres instance (e.g., on `dev-xxl`), set `DATABASE_URL`
+to the desired connection string (such as
+`postgresql+psycopg://user:password@host:5432/devops_control_tower`) before
+running migrations. Alembic automatically rewrites async drivers to synchronous
+ones during migrations.
 
 ## 🤝 Integration with Jules Dev Kit
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,7 @@
 [alembic]
 script_location = devops_control_tower/db/migrations
-sqlalchemy.url = postgresql://devops:devops@localhost:5432/devops_control_tower
+# The actual database URL is supplied by DATABASE_URL or falls back inside env.py
+sqlalchemy.url = sqlite:///./devops_control_tower.db
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/devops_control_tower/config.py
+++ b/devops_control_tower/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     
     # Database
     database_url: str = Field(
-        default="postgresql://postgres:postgres@localhost:5432/devops_control_tower",
+        default="sqlite:///./devops_control_tower.db",
         env="DATABASE_URL"
     )
     

--- a/devops_control_tower/db/migrations/env.py
+++ b/devops_control_tower/db/migrations/env.py
@@ -6,12 +6,12 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
 from alembic import context
-from sqlalchemy.engine.url import make_url
 
 # add project to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from devops_control_tower.db import models  # noqa: E402
+from devops_control_tower.db.base import DEFAULT_DATABASE_URL, get_database_url  # noqa: E402
 
 config = context.config
 
@@ -20,18 +20,12 @@ if config.config_file_name is not None:
 
 target_metadata = models.Base.metadata
 
+
 def get_url() -> str:
+    """Return a synchronous database URL for migrations."""
+
     raw = os.getenv("DATABASE_URL")
-    if not raw:
-        raise RuntimeError("DATABASE_URL environment variable is not set")
-
-    url = make_url(raw)
-
-    # If app uses asyncpg, rewrite to a sync driver for Alembic
-    if url.drivername.startswith("postgresql+asyncpg"):
-        url = url.set(drivername="postgresql+psycopg")
-
-    return str(url)
+    return get_database_url(raw or DEFAULT_DATABASE_URL)
 
 def run_migrations_offline():
     url = get_url()

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,20 +1,17 @@
-"""
-Alembic environment configuration for DevOps Control Tower.
-"""
+"""Alembic environment configuration for DevOps Control Tower."""
 
-import asyncio
-from logging.config import fileConfig
-from sqlalchemy import engine_from_config, pool
-from sqlalchemy.ext.asyncio import AsyncEngine
-from alembic import context
 import os
 import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
 
 # Add the project root to Python path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from devops_control_tower.db.base import Base, DATABASE_URL
-from devops_control_tower.db.models import EventModel, WorkflowModel, AgentModel
+from devops_control_tower.db.base import Base, DEFAULT_DATABASE_URL, get_database_url
+from devops_control_tower.db.models import AgentModel, EventModel, WorkflowModel
 
 # this is the Alembic Config object
 config = context.config
@@ -23,15 +20,16 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Set the database URL
-config.set_main_option("sqlalchemy.url", DATABASE_URL)
-
 target_metadata = Base.metadata
+
+
+def get_url() -> str:
+    return get_database_url(os.getenv("DATABASE_URL") or DEFAULT_DATABASE_URL)
 
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode."""
-    url = config.get_main_option("sqlalchemy.url")
+    url = get_url()
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -47,11 +45,7 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    connectable = engine_from_config({"sqlalchemy.url": get_url()}, prefix="sqlalchemy.", poolclass=pool.NullPool)
 
     with connectable.connect() as connection:
         context.configure(


### PR DESCRIPTION
## Summary
- default the application and Alembic to a local SQLite database when `DATABASE_URL` is not provided while forcing synchronous drivers for migrations
- update both Alembic environments to source the URL from the environment, rewrite async drivers, and avoid relying on `alembic.ini` for connectivity
- refresh configuration samples and docs to describe the sandboxed setup and remove expectations for Postgres system packages

## Testing
- python -m compileall devops_control_tower


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69324a012214832d8364482a2d271fa2)